### PR TITLE
Do not rescue the error if new file does not exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ my_old_app_production:
   database: my_old_app
 ```
 
-Then, define the define a transform in `db/transforms/my_old_app_schema.rb`:
+Then, define a transform in `db/transforms/my_old_app_schema.rb` (or `db/transforms/my_old_app_schema/my_old_app_schema.rb`
+if there are many files and you want to organize them in a folder):
 
 ```ruby
 class MyOldAppSchema < DatabaseTransform::Schema

--- a/lib/database_transform/tasks/transform.rake
+++ b/lib/database_transform/tasks/transform.rake
@@ -16,13 +16,14 @@ class DatabaseTransform::Transform
   private
 
   def require_schema
-    schema_file = @schema.underscore
-    begin
-      return require(File.join(Rails.root, 'db', 'transforms', schema_file))
-    rescue LoadError
-    end
+    schema_name = @schema.underscore
+    schema_files = [
+        File.join(Rails.root, 'db', 'transforms', schema_name),
+        File.join(Rails.root, 'db', 'transforms', schema_name, schema_name)
+    ]
 
-    require (File.join(Rails.root, 'db', 'transforms', schema_file, schema_file))
+    schema_file = schema_files.find { |f| File.exist?(f) } || schema_files.first
+    require schema_file
   end
 end
 


### PR DESCRIPTION
Currently if the first file (`db/transforms/schema_file`) exists but there is a LoadError in it, it will be rescued and then the gem directly try load the second file (`db/transforms/schema_file/schema_file`). 

Exception message of the first file is ignored then, and the new exception looks like `cannot load such file db/transforms/schema_file/schema_file`, which is confusing. 

Think we should not try to load the second file unless it exists.  And actually why we want to try another path when there is a LoadError ?
